### PR TITLE
update dependencies

### DIFF
--- a/CurlThin.Samples/CurlThin.Samples.csproj
+++ b/CurlThin.Samples/CurlThin.Samples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.7.0" />
+    <PackageReference Include="NLog" Version="5.2.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CurlThin.Tests/CurlThin.Tests.csproj
+++ b/CurlThin.Tests/CurlThin.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/CurlThin/CurlThin.csproj
+++ b/CurlThin/CurlThin.csproj
@@ -14,9 +14,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="NetUV.Core" Version="0.1.140" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Updated some dependencies due to vulnerabilities. The solution compiles but I was unable to test properly due to the fact that I cannot generate `Resources.zip` because the file at https://bintray.com/artifact/download/vszakats/generic/curl-$version-$arch-mingw.zip is no longer available. Do you have a preference for an alternate location to grab curl from?